### PR TITLE
Allow users to skip status field

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Since the issues and pull requests from this repository are also managed by this
 | `organization`     | false    | The GitHub organization that owns the projectboard. Either a user or an organization must be specified. |
 | `project_id`       | true     | The projectboard id. |
 | `resource_node_id` | true     | The id of the resource node. |
-| `status_value`     | true     | The status value to set. Must be one of the values defined in your project board **Status field settings**. |
+| `status_value`     | false    | The status value to set. Must be one of the values defined in your project board **Status field settings**. If left unspecified, new items are added without an explicit status, and existing items are left alone. |
 
 ## Getting started
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: ""
   status_value:
     description: 'Specifies the destination card to which the issue or pull request should be moved. The value must be of type string. Example: "Todo"'
-    required: true
+    required: false
     default: ""
 runs:
   using: "composite"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,15 +12,21 @@ source gh_api_lib.sh
 getProject $organization_name $organization_project_id
 
 PROJECT_ID=$(extractProjectID)
-
 ITEM_ID=$(getItemID $PROJECT_ID $resource_id)
+
+echo "PROJECT_ID: $PROJECT_ID"
+echo "ITEM_ID: $ITEM_ID"
+
+# Exit early without updating status if no status specified.
+if [ -z "$status_value" ]; then
+  exit 0
+fi
 
 STATUS_FIELD_ID=$(extractStatusFieldID)
 # select field values
 status_value_OPTION_ID=$(extractStatusFieldNodeSettingsByValue "$status_value")
 
-echo "PROJECT_ID: $PROJECT_ID"
-echo "ITEM_ID: $ITEM_ID"
+
 echo "STATUS_FIELD_ID: $STATUS_FIELD_ID"
 echo "status_value_OPTION_ID: $status_value_OPTION_ID"
 


### PR DESCRIPTION
This PR makes the `status_value` setting optional; without it, items will just be inserted into Project boards without setting their status.

This means that:
- New issues will go wherever the project workflow moves issues to by default, and
- Existing issues will not have their status changed.

Useful when pushing issues to a project board managed by its own workflows.