### PR TITLE
feature: install gh cli if not present

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ branding:
 runs:
   using: "composite"
   steps:
+    - name: "Install the gh cli tool if not installed"
+      shell: bash
+      run: ./deps.sh
+
     - name: "Error missing auth conf"
       if: inputs.gh_app_secret_key == '' && inputs.gh_app_ID == '' && inputs.gh_token == ''
       shell: bash

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# check if gh binary is available
+if [ -x "$(command -v gh)" ]; then
+    echo 'gh cli is installed.'
+    exit 0
+fi
+
+version=${GH_CLI_VERSION:-2.8.0}
+echo "Installing gh cli in version: $version"
+
+wget https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz
+tar -xvf gh_${version}_linux_amd64.tar.gz
+sudo cp $(pwd)/gh_${version}_linux_amd64/bin/gh /usr/local/bin/


### PR DESCRIPTION
This PR implements a check if the *gh* cli is available and installs it from source otherwise.

If you know that your system does not provide this binary, you can also customize the version to be installed. To do this, simply specify an environment variable named ``GH_CLI_VERSION`` and the version string. When you declare such a variable, make sure that you follow the vendor's semver principle and do not prefix the version with a "v".

Example:

```yaml
jobs:
  task:
    name: task
    runs-on: ubuntu-latest
    steps:
      - name: Do Something
        uses: leonsteinhaeuser/project-beta-automations@vX.X.X
        env:
           GH_CLI_VERSION: 2.8.0
        ...
```

Why did I choose to install from sources?

Since I don't want to mess with keys and package managers, I decided to simplify this process and download the binary directly from the sources. Otherwise I would have to check which package manager is available, what the package name is and so on.

Closes: #38