### PR TITLE
fix: positive actions state on error call

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+set -e
+
 if [ "$DEBUG_COMMANDS" = "true" ]; then
-    set -ex
+    set -x
 fi
 
 # DEBUG_MODE_ENABLED provides a way to enable the debug mode


### PR DESCRIPTION
This PR fixes a problem that occurs when the underlying call fails and the action was marked as positive.

Fixes: #53

![failure_call](https://user-images.githubusercontent.com/42437185/192096416-de0c61b2-2b5b-4108-a9ab-82bb1d834b43.png)
