### PR TITLE
Updating documentation for required permissions when using GH App auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ To leverage the App authentication with this action the following steps are need
   - Repo: Checks: RO
   - Repo: Contents: RO
   - Repo: Environments: RO
+  - Repo: Issues RW
   - Repo: Metadata: RO
   - Repo: PR: RW
   - Repo: Commit statuses: RO

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To leverage the App authentication with this action the following steps are need
   - Repo: Checks: RO
   - Repo: Contents: RO
   - Repo: Environments: RO
-  - Repo: Issues RW
+  - Repo: Issues: RW
   - Repo: Metadata: RO
   - Repo: PR: RW
   - Repo: Commit statuses: RO


### PR DESCRIPTION
In my testing I found that a `gh: Resource not accessible by integration` error was encountered when the GH App permissions are set according to the [README's current state](https://github.com/leonsteinhaeuser/project-beta-automations#gh-app-auth).

After setting the repo issues permission to read-write for the GH app issues were moved to the target project as expected.