### PR TITLE
Eliminate quotes from text data in custom field

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,8 +130,9 @@ function updateFieldScope() {
                     log="$log\n\n$nameField: $fieldID"
                     case $typeField in
                         'text')
-                            log="$log\nUpdating text field: $nameField with value: $valueField"
-                            response=$(updateTextField "$PROJECT_UUID" "$PROJECT_ITEM_UUID" $fieldID "$valueField")
+                            valueFieldWithoutQuotes=$(echo $valueField | sed 's/\"//g')
+                            log="$log\nUpdating text field: $nameField with value: $valueFieldWithoutQuotes"
+                            response=$(updateTextField "$PROJECT_UUID" "$PROJECT_ITEM_UUID" $fieldID "$valueFieldWithoutQuotes")
                             log="$log\n$response\n"
                             ;;
                         "number")


### PR DESCRIPTION
The data of Number and Date type in custom field don't include quotes but Text data does.
This PR eliminates the quotes from Text data to align the data format with other data types.