### PR TITLE
Fixed wrong default for `gh_host`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   gh_host:
     description: 'The hostname will be used by gh-cli. This works for enterprise customers.'
     required: false
-    default: "api.github.com"
+    default: "github.com"
   gh_token:
     description: 'Permission token that grants permission to the GitHub API. (Toke or App config is required)'
     required: false


### PR DESCRIPTION
Without this change workflows that do not specify `gh_host` were generating the following error:

![image](https://github.com/leonsteinhaeuser/project-beta-automations/assets/57403/79b8aa64-62a7-4675-bae3-44a84cc5ffdc)
